### PR TITLE
Set the default chips for languages

### DIFF
--- a/branchout-ui/src/pages/PreferencesPage.jsx
+++ b/branchout-ui/src/pages/PreferencesPage.jsx
@@ -3,7 +3,7 @@ import { Container, Divider, Chip } from '@mui/material';
 import './PreferencesPage.css';
 
 const LEVELS = ['1st Year', '2nd Year', '3rd Year', '4th Year'];
-const LANGUAGES = ['JavaScript', 'Python', 'Java', 'C++']; 
+const LANGUAGES = ['JavaScript', 'Python', 'Java', 'C++', 'Ruby', 'Go', 'Rust', 'Swift', 'Kotlin', 'PHP', 'TypeScript', 'C#', 'C', 'HTML/CSS', 'SQL']; 
 const TAGS = ['Web', 'AI', 'Mobile', 'Data Science'];
 
 
@@ -26,6 +26,7 @@ function PreferencesPage() {
             <h1>Preferences Page</h1>
             <p>Click tags on each section that align with your preferred level, languages, and tags! </p>
             <Divider />
+            <h2>Level</h2>
             <p>Set your school level - think of 1st as freshman and 4th as senior! This will correlate to the level repositories you get in your feed.</p>
             {LEVELS.map (level => (
                 <Chip
@@ -41,9 +42,23 @@ function PreferencesPage() {
             ))}
             
             <Divider />
+            <h2>Languages</h2>
             <p>Set any languages you know (or want to know) here </p>
 
+            {LANGUAGES.map (lang => (
+                <Chip
+                    key={lang}
+                    label={lang}
+                    onClick={() => {
+                        handleToggle(lang, selectedLanguages, setSelectedLanguages)}}
+                    color={selectedLanguages.includes(lang) ? 'primary' : 'default'}
+                    variant={selectedLanguages.includes(lang) ? 'filled' : 'outlined'}
+                    clickable
+                    sx={({ marginRight: 1, margin: 1})}
+                />
+            ))}
             <Divider />
+            <h2>Tags</h2>
             <p>Set any tags of topics that you know or want to know here</p>
 
             <Divider />


### PR DESCRIPTION
## What does this PR do?
This code maps through our predetermined languages (top 20) and displays a toggleable tags that upon click, change visually and get added to an array.

## Context or Background
This pr works to make the preference page more comprehensive, allowing users to select levels to later send back to the backend.

## Checklist
- [x] Code compiles without errors
- [x] New features/fixes have been tested
- [x] Docs/README updated if needed

##  Related Ticket (Trello task link)
<!-- References <[link](https://trello.com/c/vCsaN6V1/52-preference-field-languages-field)> -->

##  Screenshots (if applicable)
<img width="1143" height="746" alt="image" src="https://github.com/user-attachments/assets/59cf5d2d-0bab-41c8-b0f8-693f998a52cd" />

---