### PR TITLE
tweaked fields to only save upon btn click

### DIFF
--- a/branchout-ui/src/pages/PreferencesPage.jsx
+++ b/branchout-ui/src/pages/PreferencesPage.jsx
@@ -12,12 +12,19 @@ function PreferencesPage() {
     const [selectedLanguages, setSelectedLanguages] = useState([]);
     const [selectedTags, setSelectedTags] = useState([]);
 
-    // Log arrays when they change
+    // load the specific users preferences from the api with a useEffect to prevent block the ui
     useEffect(() => {
-        console.log('Selected Levels:', selectedLevels);
-        console.log('Selected Languages:', selectedLanguages);
-        console.log('Selected Tags:', selectedTags);
-    }, [selectedLevels, selectedLanguages, selectedTags]);
+        fetch('/user/preferences') // endpoint still needs to be created (and handle GET/POST)
+            .then(res => res.json())
+            .then(data => {
+                setSelectedLevels(data.skill || []);
+                setSelectedLanguages(data.languages || []);
+                setSelectedTags(data.preferenceTags || []);
+            })
+            .catch(err => {
+                // handle error if needed
+            });
+    }, []);
 
     const handleToggle = (item, selectedArray, setSelectedArray) => {
         setSelectedArray(prev =>
@@ -27,10 +34,23 @@ function PreferencesPage() {
         );
     };
 
+    const handleSave = () => {
+        // API call should go here to save user details/preferences
+        const preferences = {
+            levels: selectedLevels,
+            languages: selectedLanguages,
+            tags: selectedTags,
+        };
+        // example saving using stringify: { method: 'POST', body: JSON.stringify(preferences) })
+        // code rn just logs the preferences
+        console.log('Saving preferences as follows:', preferences);
+    };
+
     return (
 
         <Container maxWidth="xl">
             <h1>Preferences Page</h1>
+            <button onClick={handleSave}>Save Preferences</button>
             <p>Click tags on each section that align with your preferred level, languages, and tags! </p>
             <Divider />
             <h2>Level</h2>


### PR DESCRIPTION
## What does this PR do?
This code adds a useEffect hook to set up a load (end point for user/preferences) for the users specific preferences from the api. It also has a function and button to handle the preference saving for a user.

## Context or Background
Prior to this code, the user preferences were set on change (on toggle of each one), which, once connected to the backend, would make too many network requests. This code sets up the fetch (which should eventually be axios.get) and post of the users preference fields to be upon load of the preference page and post upon save, respectively.

## Checklist
- [x] Code compiles without errors
- [x] New features/fixes have been tested
- [x] Docs/README updated if needed

##  Related Ticket (Trello task link)
<!-- References <[link](https://trello.com/c/MmEGRs3p/58-tweak-set-all-preference-fields-for-a-user-by-clicking-on-a-save-button-at-the-top-so-its-not-on-change)> -->

##  Screenshots (if applicable)
<img width="602" height="330" alt="image" src="https://github.com/user-attachments/assets/e77ad1ef-0d9c-4ebd-98e6-175aff43f50e" />

---