### PR TITLE
added logic to the github helper function to pull specific repos

### DIFF
--- a/branchout-api/helpers/githubHelper.js
+++ b/branchout-api/helpers/githubHelper.js
@@ -1,0 +1,22 @@
+const axios = require('axios'); // import axios for making HTTP requests to the GitHub API
+
+
+async function fetchReposWithFilters({ startDate, endDate }) {
+    // Filters: Must have a MIT license, must have at least one good first issue, and must be created between a startDate and endDate
+    const query = `license:mit good-first-issues:>0 created:${startDate}..${endDate}`;
+
+    // actual full search API URL - encoded component hides the full url
+    const url = `https://api.github.com/search/repositories?q=${encodeURIComponent(query)}&sort=stars&order=desc&per_page=10`;
+
+    const response = await axios.get(url, {
+        headers: {
+        Authorization: `token ${process.env.GITHUB_TOKEN}`,
+        Accept: "application/vnd.github+json"
+        }
+    });
+
+    return response.data.items; // returns a promise array of matching objects
+}
+
+module.exports = { fetchReposWithFilters }; // Export the function so it can be used in other parts of the project (cron job)
+


### PR DESCRIPTION
## What does this PR do?
This code works to fetch only specific repositories using the GitHub API. It uses a specific query to look for those repositories that qualify it as open-source, such as being licensed by MIT, having at least one good first issue, and limited between a time section. Should just return  an array of those objects that matches these constraints.

## Context or Background
This functionality is needed as part of the actual CRON job functionality, as it will populate the job with the information necessary to prompt our AI model.

## Checklist
- [x] Code compiles without errors
- [x] New features/fixes have been tested
- [x] Docs/README updated if needed

##  Related Ticket (Trello task link)
<!-- References <[link](https://trello.com/c/zLUy8239/17-cron-github-api-integration)> -->

##  Screenshots (if applicable)

---