### PR TITLE
pulled all repos on backend to be visible in card/modal

### DIFF
--- a/branchout-api/routes/repoRoutes.js
+++ b/branchout-api/routes/repoRoutes.js
@@ -4,8 +4,8 @@ const repoController = require("../controllers/repoController");
 const { authenticate, requireAdmin } = require("../middleware/authCheck");
 const router = express.Router();
 
-router.get('/', authenticate, requireAdmin, repoController.getAllRepos);
-router.get('/:id', authenticate, requireAdmin, repoController.getByID);
+router.get('/', repoController.getAllRepos);
+router.get('/:id', repoController.getByID);
 router.post('/', authenticate, requireAdmin, repoController.create);
 router.put('/:id', authenticate, requireAdmin, repoController.update);
 router.delete('/:id', authenticate, requireAdmin, repoController.delete);

--- a/branchout-ui/package.json
+++ b/branchout-ui/package.json
@@ -16,6 +16,7 @@
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^7.2.0",
     "@mui/material": "^7.2.0",
+    "axios": "^1.10.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-mui-sidebar": "^1.6.3",

--- a/branchout-ui/src/components/RepoCard/RepoCard.css
+++ b/branchout-ui/src/components/RepoCard/RepoCard.css
@@ -1,6 +1,6 @@
 .repo-card {
-  width: 300px;
-  height: 400px;
+  width: 700px;
+  height: 1000px;
   margin: 20px;
   transition: transform 0.3s ease-in-out;
 display: flex;

--- a/branchout-ui/src/components/RepoCard/RepoCard.jsx
+++ b/branchout-ui/src/components/RepoCard/RepoCard.jsx
@@ -200,7 +200,7 @@ export default function RepoCard({ repo, onSwipeLeft, onSwipeRight }) {
               </div>
               <div className="repo-card-rating">
                 <Typography variant="body2" color="text.secondary">
-                  Rating: {repo.rating || "N/A"}
+                  Rating: {repo.stars || "N/A"}
                 </Typography>
               </div>
             </div>

--- a/branchout-ui/src/components/RepoCardModal/RepoCardModal.jsx
+++ b/branchout-ui/src/components/RepoCardModal/RepoCardModal.jsx
@@ -48,7 +48,7 @@ export default function RepoCardModal({ open, handleClose , repo}) {
             }}
           />
           <Box id="repo-modal-rating" sx={{ mt: 2 }}>
-            <span style={{ color: "#E83F25", fontWeight: 600 }}>Rating:</span> {repo.rating || "N/A"}
+            <span style={{ color: "#E83F25", fontWeight: 600 }}>Rating:</span> {repo.stars || "N/A"}
           </Box>
           <Box id="repo-modal-tags" sx={{ mt: 2 }}>
             <span style={{ color: "#E83F25", fontWeight: 600 }}>Tags:</span>{" "}

--- a/branchout-ui/src/pages/DiscoveryPage/DiscoveryPage.jsx
+++ b/branchout-ui/src/pages/DiscoveryPage/DiscoveryPage.jsx
@@ -1,16 +1,33 @@
 // Example usage in your parent component
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import RepoCard from '../../components/RepoCard/RepoCard';
 import { Box, CssBaseline } from '@mui/material';
+import axios from "axios";
+
 
 const DiscoveryPage = () => {
   const [repos, setRepos] = useState([
-    { id: 1, name: 'Repo 1', description: 'First repository', tags: ['Machine Learning', 'React'], rating: 4.5 },
-    { id: 2, name: 'Repo 2', description: 'Second repository', tags: ['MCP', "Android Development", 'Java'] , rating: 2000},
-    { id: 3, name: 'Repo 3', description: 'Third repository', tags: ['Web Development', 'Node.js'], rating: 4600 },
+    // { id: 1, name: 'Repo 1', description: 'First repository', tags: ['Machine Learning', 'React'], rating: 4.5 },
+    // { id: 2, name: 'Repo 2', description: 'Second repository', tags: ['MCP', "Android Development", 'Java'] , rating: 2000},
+    // { id: 3, name: 'Repo 3', description: 'Third repository', tags: ['Web Development', 'Node.js'], rating: 4600 },
   ]);
+
+  const [loading, setLoading] = useState(true);
   
   const [currentIndex, setCurrentIndex] = useState(0);
+
+  const VITE_URL = import.meta.env.VITE_URL;
+
+  useEffect(() => {
+    axios
+      .get(`${VITE_URL}/repo/`)
+      .then((res) => {
+        setRepos(res.data);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, []);
+
 
   const handleSwipeLeft = (repo) => {
     console.log('Swiped left on:', repo.name);


### PR DESCRIPTION
## What does this PR do?
This code brings in a useEffect hook that brings up all the repos and their data. This is so that on the front end card, and the modal, the proper information populates. I did some minor tweaks to the styling to get the whole card to show.
## Context or Background
This is one of the final pieces to getting the front end to fetch from the backend as far as repos.
## Checklist
- [x] Code compiles without errors
- [x] New features/fixes have been tested
- [x] Docs/README updated if needed

##  Related Ticket (Trello task link)
Reference: [Connect repo front to backend](https://trello.com/c/EppuU0fu/68-connect-repo-front-to-backend) 

##  Screenshots (if applicable)
<img width="1452" height="1283" alt="image" src="https://github.com/user-attachments/assets/1726752a-b1d7-4b9d-a1e3-174c1fe6e90a" />

<img width="1432" height="1280" alt="image" src="https://github.com/user-attachments/assets/ce21e792-e8fc-4022-a178-45f491fdf175" />

---