### PR TITLE
fixed rediraction logic that took you to login page

### DIFF
--- a/branchout-ui/src/components/ProtectedRoute/ProtectedRoute.jsx
+++ b/branchout-ui/src/components/ProtectedRoute/ProtectedRoute.jsx
@@ -3,12 +3,13 @@ import { useUser } from '@clerk/clerk-react';
 import { useState, useEffect } from 'react';
 
 // Check if user is authenticated (either Clerk or local)
-const useAuth = () => {
-  const { user: clerkUser } = useUser();
+export const useAuth = () => {
+  const { user: clerkUser , isLoaded} = useUser();
   const [localUser, setLocalUser] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
+    if (!isLoaded) return; 
     const checkLocalAuth = () => {
       const token = localStorage.getItem('authToken');
       const userData = localStorage.getItem('userData');
@@ -32,12 +33,12 @@ const useAuth = () => {
     };
 
     checkLocalAuth();
-  }, []);
+  }, [isLoaded]);
 
   return {
     user: clerkUser || localUser,
     isLoading,
-    isAuthenticated: !!(clerkUser || localUser)
+    isAuthenticated: !!(clerkUser || localUser),
   };
 };
 
@@ -63,6 +64,7 @@ export const ProtectedRoute = ({ children }) => {
     // Redirect to login with the current location they were trying to access
     return <Navigate to="/login" state={{ from: location }} replace />;
   }
+
 
   return children;
 };


### PR DESCRIPTION
## What does this PR do?
- The user was being sent to login even when signed in, so I made it so that didn't happen anymore
- There is no /repo/saved endpoint, so no it just gets the logged in user's info and filters for saved repos instead

## Context or Background
<!-- Explain the problem this PR is solving or the motivation for the change -->

## Checklist
- [X] Code compiles without errors
- [X] New features/fixes have been tested
- [X] Docs/README updated if needed

##  Related Ticket (Trello task link)
<!-- References <link> -->
[Trello Card](https://trello.com/c/gWgsQ9IO/49-saved-repos-page)

##  Screenshots (if applicable)
<!-- Drag and drop or paste images here -->
<img width="1686" height="992" alt="Screenshot 2025-07-22 at 11 07 54 AM" src="https://github.com/user-attachments/assets/e0d96963-4e68-4a0f-99b4-9e398fbaec0e" />

---