### PR TITLE
created swipe logic endpoint for repo feedback

### DIFF
--- a/branchout-api/controllers/repoController.js
+++ b/branchout-api/controllers/repoController.js
@@ -159,6 +159,43 @@ exports.filterRepos = async (req, res) => {
     }
 }
 
+// create feed back entry
+
+exports.handleSwipe = async (req, res) => {
+    const {userId, repoId, direction, feedbackRepo} = req.body;
+
+    if (!userId || !repoId || !direction){
+        return res.status(400).json({ error: "Missing required fields!!"});
+    }
+
+    try {
+        // create the feedback in the first place
+        const feedback = await prisma.feedBack.create({
+            data: {
+                swipeDirection: direction,
+                feedbackReason: feedbackReason ?? null,
+                user: {connect: {id: userId}},
+                repo: {connect: {id: repoId}},
+            },
+        });
+
+        if (direction === "RIGHT"){
+            await prisma.user.update({
+                where: {id: userId},
+                data: {
+                    savedRepos:{
+                        connect: {id: repoId},
+                    },
+                },
+            });
+        }
+        res.status(201).json({message: "Swipe Stored", feedback});
+    } catch (error) {
+        res.status(500).json({err: "Failed to handle swip :("});
+    }
+
+};
+
 
 
 

--- a/branchout-api/routes/repoRoutes.js
+++ b/branchout-api/routes/repoRoutes.js
@@ -10,6 +10,7 @@ router.post('/', authenticate, requireAdmin, repoController.create);
 router.put('/:id', authenticate, requireAdmin, repoController.update);
 router.delete('/:id', authenticate, requireAdmin, repoController.delete);
 router.get('/', authenticate, requireAdmin, repoController.filterRepos);
+router.post('/swipe', authenticate, requireAdmin, repoController.handleSwipe);
 
 module.exports = router;
 


### PR DESCRIPTION
## What does this PR do?
Built the repo endpoint to store feedback of a repo for a user based on swipe direction. This endpoint also leaves the feedback reason open, which ideally on the front end would look something like a set of options from the enum that lets users pick a static reason for swiping left. This endpoint just creates and stores that feedback reason.
## Context or Background
As part of the MVP and the reccomendation algorithm, we need to have a way to store and recall feedback on swipe of a repo.
## Checklist
- [x] Code compiles without errors
- [x] New features/fixes have been tested
- [x] Docs/README updated if needed

##  Related Ticket (Trello task link)
References: [Connecting repo swipe to store on backend](https://trello.com/c/b0eQdWNp/57-connect-repo-swipe-to-store-on-backend)

##  Screenshots (if applicable)
<!-- Drag and drop or paste images here -->

---