### PR TITLE
Cleaned input, accurately store swipe/feedback

### DIFF
--- a/branchout-api/controllers/repoController.js
+++ b/branchout-api/controllers/repoController.js
@@ -159,6 +159,44 @@ exports.filterRepos = async (req, res) => {
     }
 }
 
+// create feed back entry
+
+exports.handleSwipe = async (req, res) => {
+    const {userId, repoId, direction, feedbackReason} = req.body;
+
+    if (!userId || !repoId || !direction){
+        return res.status(400).json({ error: "Missing required fields!!"});
+    }
+
+    try {
+        // create the feedback in the first place
+        const feedback = await prisma.feedBack.create({
+            data: {
+                swipeDirection: direction,
+                feedbackReason: feedbackReason ?? null,
+                user: {connect: {id: userId}},
+                repo: {connect: {id: repoId}},
+            },
+        });
+
+        if (direction === "RIGHT"){
+            await prisma.user.update({
+                where: {id: userId},
+                data: {
+                    savedRepos:{
+                        connect: {id: repoId},
+                    },
+                },
+            });
+        }
+        res.status(201).json({message: "Swipe Stored", feedback});
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({err: "Failed to handle swip :("});
+    }
+
+};
+
 
 
 

--- a/branchout-api/routes/repoRoutes.js
+++ b/branchout-api/routes/repoRoutes.js
@@ -10,6 +10,7 @@ router.post('/', authenticate, requireAdmin, repoController.create);
 router.put('/:id', authenticate, requireAdmin, repoController.update);
 router.delete('/:id', authenticate, requireAdmin, repoController.delete);
 router.get('/', authenticate, requireAdmin, repoController.filterRepos);
+router.post('/swipe', repoController.handleSwipe);
 
 module.exports = router;
 

--- a/branchout-ui/src/components/Feedback/CritiqueChips.jsx
+++ b/branchout-ui/src/components/Feedback/CritiqueChips.jsx
@@ -1,0 +1,30 @@
+// components/CritiqueChips.jsx
+import React from "react";
+import { Chip, Box, Typography } from "@mui/material";
+
+const CritiqueChips = ({ onSelect }) => {
+const options = [
+    { label: "Not Interested", value: "NOTINTERESTED" },
+    { label: "Misleading", value: "MISLEADING" },
+    { label: "Too Complex", value: "TOOCOMPLEX" },
+    { label: "Too Easy", value: "TOOEASY" }
+];
+
+return (
+    <Box sx={{ mt: 2 }}>
+    <Typography variant="subtitle1">Why did you dislike this repository?</Typography>
+    <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", mt: 1 }}>
+        {options.map((option) => (
+        <Chip
+            key={option.value}
+            label={option.label}
+            clickable
+            onClick={() => onSelect(option.value)}
+        />
+        ))}
+    </Box>
+    </Box>
+);
+};
+
+export default CritiqueChips;

--- a/branchout-ui/src/pages/DiscoveryPage/DiscoveryPage.jsx
+++ b/branchout-ui/src/pages/DiscoveryPage/DiscoveryPage.jsx
@@ -1,10 +1,20 @@
 // Example usage in your parent component
 import { useState, useEffect } from 'react';
 import RepoCard from '../../components/RepoCard/RepoCard';
-import { Box, CssBaseline } from '@mui/material';
+import CritiqueChips from '../../components/Feedback/CritiqueChips';
+import { Box, CssBaseline, Modal, Backdrop, Fade } from '@mui/material';
+import { useAuth, useUser } from '@clerk/clerk-react';
 import axios from 'axios';
 
+
 const DiscoveryPage = () => {
+  const CRITIQUE_OPTIONS = [
+    "NOTINTERESTED",
+    "MISLEADING",
+    "TOOCOMPLEX",
+    "TOOEASY"
+  ];
+  
   const [repos, setRepos] = useState([
 // { id: 1, name: 'Repo 1', description: 'First repository', tags: ['Machine Learning', 'React'], rating: 4.5 },
 //  { id: 2, name: 'Repo 2', description: 'Second repository', tags: ['MCP', "Android Development", 'Java'] , rating: 2000},
@@ -12,9 +22,25 @@ const DiscoveryPage = () => {
   
 ]);
 
+  const { user: clerkUser } = useUser();
   const [loading, setLoading] = useState(true);
-  
   const [currentIndex, setCurrentIndex] = useState(0);
+  const [showFeedbackModal, setShowFeedbackModal] = useState(false);
+  const [selectedRepo, setSelectedRepo] = useState(null);
+  const { getToken } = useAuth();
+
+  const localUser = (() => {
+    try {
+      const userData = localStorage.getItem("userData");
+      return userData ? JSON.parse(userData) : null;
+    } catch {
+      return null;
+    }
+  })();
+
+  // Final user
+  const user = clerkUser || localUser;
+  const userId = user?.id;
 
   const VITE_URL = import.meta.env.VITE_DATABASE_URL;
 
@@ -36,15 +62,88 @@ const DiscoveryPage = () => {
 
   const handleSwipeLeft = (repo) => {
     console.log('Swiped left on:', repo.name);
-    // Move to next card
+    console.log('Swiped left on:', repo.name);
+    setSelectedRepo(repo);
+    setShowFeedbackModal(true); // show chips modal
+  };
+
+  const handleSwipeRight = async (repo) => {
+    
+    try {
+      const token = await getToken();
+      await axios.post(`${VITE_URL}/repo/swipe`, {
+        userId: user?.id,  // this works for both Clerk and local
+        repoId: repo.id,
+        direction: "RIGHT"
+      }, {
+        headers: {
+          Authorization: `Bearer ${token}`
+      }
+    });
+
+    console.log('Feedback submitted');
+    } catch (err) {
+      console.error("Swipe RIGHT failed", err);
+    }
+  
     setCurrentIndex(prev => (prev + 1) % repos.length);
   };
 
-  const handleSwipeRight = (repo) => {
-    console.log('Swiped right on:', repo.name);
-    // Move to next card
+  const handleCritiqueSelect = async (reason) => {
+    // try {
+    //   const token = await getToken();
+  
+    //   await axios.post(`${VITE_URL}/repo/swipe`, {
+    //     userId: clerkUser?.id,
+    //     repoId: selectedRepo.id,
+    //     direction: "LEFT", // <-- you had "swipeDirection" before; make sure this matches your backend field
+    //     feedbackReason: reason
+    //   }, {
+    //     headers: {
+    //       Authorization: `Bearer ${token}`
+    //     }
+    //   });
+  
+    //   console.log('Feedback submitted');
+    // } catch (error) {
+    //   console.error('Error sending feedback:', error);
+    // }
+  
+    // setShowFeedbackModal(false);
+    // setSelectedRepo(null);
+    // setCurrentIndex(prev => (prev + 1) % repos.length);
+    // if (!isClerkLoaded || !clerkUser?.id) {
+    //   console.warn("User not ready — can't submit feedback yet.");
+    //   return;
+    // }
+    
+    try {
+      const token = await getToken();
+      const payload = {
+        userId: user?.id,  // this works for both Clerk and local
+        repoId: selectedRepo?.id,
+        direction: "LEFT",
+        feedbackReason: reason
+      };
+  
+      console.log("Sending swipe payload:", payload);
+  
+      await axios.post(`${VITE_URL}/repo/swipe`, payload, {
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      });
+  
+      console.log('Feedback submitted');
+    } catch (error) {
+      console.error('Error sending feedback:', error.response?.data || error.message);
+    }
+  
+    setShowFeedbackModal(false);
+    setSelectedRepo(null);
     setCurrentIndex(prev => (prev + 1) % repos.length);
   };
+  
 
   const drawerWidth = 270;
 
@@ -76,6 +175,27 @@ const DiscoveryPage = () => {
           />
         )}
     </Box>
+    <Modal
+      open={showFeedbackModal}
+      onClose={() => setShowFeedbackModal(false)}
+      closeAfterTransition
+    >
+      <Fade in={showFeedbackModal}>
+        <Box sx={{
+          position: 'absolute',
+          top: '50%',
+          left: '50%',
+          transform: 'translate(-50%, -50%)',
+          width: 400,
+          bgcolor: 'background.paper',
+          borderRadius: 2,
+          boxShadow: 24,
+          p: 4,
+        }}>
+        <CritiqueChips onSelect={handleCritiqueSelect} />
+        </Box>
+      </Fade>
+    </Modal>
     </Box>
   );
 }


### PR DESCRIPTION
## What does this PR do?
This PR sets the logic to be able to pull the logged-in users id in order to save any repo swipe information to that user (by relation). A use effect hook was then introduce to handle this logic, ie it awaits feedback on a left swipe and stores that, and on right swipe it simply stores the repository for the user. The feedback is established by using predetermined critiques - this logic goes on in the critique chips jsx file. The UI accurately lets the user chose a chip and upon that chosen chip, it closes the component and on the discovery page logic, it sends that critique back as feedback.

## Context or Background
This was needed because the current endpoint established in a PR prior to this, only handled the logic for a right swipe on a repository. Now, it handles both left and right and posts the feedback to the model in relation to the user and their repos.
## Checklist
- [x] Code compiles without errors
- [x] New features/fixes have been tested
- [x] Docs/README updated if needed

##  Related Ticket (Trello task link)
References : https://trello.com/c/Ax4eNhYp/71-displaying-swipe-left-reason-on-ui-form-enum

##  Screenshots (if applicable)
<!-- Drag and drop or paste images here -->

---