### PR TITLE
Fixed branch, cleaned input and stored

### DIFF
--- a/branchout-api/controllers/repoController.js
+++ b/branchout-api/controllers/repoController.js
@@ -162,7 +162,7 @@ exports.filterRepos = async (req, res) => {
 // create feed back entry
 
 exports.handleSwipe = async (req, res) => {
-    const {userId, repoId, direction, feedbackRepo} = req.body;
+    const {userId, repoId, direction, feedbackReason} = req.body;
 
     if (!userId || !repoId || !direction){
         return res.status(400).json({ error: "Missing required fields!!"});
@@ -191,6 +191,7 @@ exports.handleSwipe = async (req, res) => {
         }
         res.status(201).json({message: "Swipe Stored", feedback});
     } catch (error) {
+        console.error(error);
         res.status(500).json({err: "Failed to handle swip :("});
     }
 

--- a/branchout-api/routes/repoRoutes.js
+++ b/branchout-api/routes/repoRoutes.js
@@ -10,7 +10,7 @@ router.post('/', authenticate, requireAdmin, repoController.create);
 router.put('/:id', authenticate, requireAdmin, repoController.update);
 router.delete('/:id', authenticate, requireAdmin, repoController.delete);
 router.get('/', authenticate, requireAdmin, repoController.filterRepos);
-router.post('/swipe', authenticate, requireAdmin, repoController.handleSwipe);
+router.post('/swipe', repoController.handleSwipe);
 
 module.exports = router;
 

--- a/branchout-ui/src/components/Feedback/CritiqueChips.jsx
+++ b/branchout-ui/src/components/Feedback/CritiqueChips.jsx
@@ -1,0 +1,30 @@
+// components/CritiqueChips.jsx
+import React from "react";
+import { Chip, Box, Typography } from "@mui/material";
+
+const CritiqueChips = ({ onSelect }) => {
+const options = [
+    { label: "Not Interested", value: "NOTINTERESTED" },
+    { label: "Misleading", value: "MISLEADING" },
+    { label: "Too Complex", value: "TOOCOMPLEX" },
+    { label: "Too Easy", value: "TOOEASY" }
+];
+
+return (
+    <Box sx={{ mt: 2 }}>
+    <Typography variant="subtitle1">Why did you dislike this repository?</Typography>
+    <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", mt: 1 }}>
+        {options.map((option) => (
+        <Chip
+            key={option.value}
+            label={option.label}
+            clickable
+            onClick={() => onSelect(option.value)}
+        />
+        ))}
+    </Box>
+    </Box>
+);
+};
+
+export default CritiqueChips;


### PR DESCRIPTION
## What does this PR do?
This branch fixes PR merge conflicts with the previous branch. But to reiterate, this PR sets the logic to be able to pull the logged-in users id in order to save any repo swipe information to that user (by relation). A use effect hook was then introduce to handle this logic, ie it awaits feedback on a left swipe and stores that, and on right swipe it simply stores the repository for the user. The feedback is established by using predetermined critiques - this logic goes on in the critique chips jsx file. The UI accurately lets the user chose a chip and upon that chosen chip, it closes the component and on the discovery page logic, it sends that critique back as feedback.

## Context or Background
This was needed because the current endpoint established in a PR prior to this, only handled the logic for a right swipe on a repository. Now, it handles both left and right and posts the feedback to the model in relation to the user and their repos.

## Checklist
- [x] Code compiles without errors
- [x] New features/fixes have been tested
- [x] Docs/README updated if needed

##  Related Ticket (Trello task link)
References: [Send swipe reason to backend](https://trello.com/c/Ax4eNhYp/71-displaying-swipe-left-reason-on-ui-form-enum)

---