### PR TITLE
UI tweaks to saved repos view

### DIFF
--- a/branchout-ui/src/components/RepoCard/RepoCard.css
+++ b/branchout-ui/src/components/RepoCard/RepoCard.css
@@ -1,6 +1,6 @@
 .repo-card {
   width: 700px;
-  height: 1000px;
+  height: 800px;
   margin: 20px;
   transition: transform 0.3s ease-in-out;
 display: flex;
@@ -23,4 +23,14 @@ cursor: pointer;
     align-items: center;
     gap: 8px;
     margin-top: 8px;
+}
+
+.repo-card-languages{
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+  margin-top: 8px;
 }

--- a/branchout-ui/src/components/RepoCard/RepoCard.jsx
+++ b/branchout-ui/src/components/RepoCard/RepoCard.jsx
@@ -138,7 +138,7 @@ export default function RepoCard({ repo, onSwipeLeft, onSwipeRight }) {
       <Card
         ref={cardRef}
         sx={{
-          maxWidth: 345,
+          maxWidth: 400,
           borderRadius: 3, // Rounded corners
           boxShadow: 6,    // Elevation/shadow
           overflow: "hidden",
@@ -165,50 +165,114 @@ export default function RepoCard({ repo, onSwipeLeft, onSwipeRight }) {
         className="repo-card"
       >
         <CardActionArea>
-          <Typography gutterBottom variant="h5" component="div" sx={{ fontWeight: 700, letterSpacing: 1 }}>
+          {/* <Typography gutterBottom variant="h5" component="div" sx={{ fontWeight: 700, letterSpacing: 1 }}>
             {repo.name}
-          </Typography>
-          <CardMedia
-            onClick={handleCardClick}
-            component="img"
-            height="140"
-            image="https://mui.com/static/images/cards/contemplative-reptile.jpg"
-            alt={repo.name ? `Image of ${repo.name}` : "Repository image"}
-            sx={{
-              borderRadius: 2,
-              boxShadow: 2,
-              objectFit: "cover",
-              marginBottom: 1,
-              cursor: "pointer",
-              transition: "transform 0.2s",
-            }}
-          />
-          <CardContent  sx={{ padding: 3 }}>
-            <div className="repo-card-labels">
-              <div className="repo-card-tags">
-                {repo.tags?.map((tag) => (
-                  <Chip
-                    key={tag}
-                    label={tag}
-                    variant="outlined"
-                    sx={{ 
-                      margin: "2px",
-                      borderRadius: "10px", // <-- Change this value as you like
-                    }}
-                  />
-                ))}
-              </div>
-              <div className="repo-card-rating">
-                <Typography variant="body2" color="text.secondary">
-                  Rating: {repo.stars || "N/A"}
-                </Typography>
-              </div>
-            </div>
+          </Typography> */}
 
-            <Typography variant="body2" sx={{ color: "text.secondary" }}>
-              {repo.summary || "No summary available"}
+          {/* <Card sx={{ borderRadius: 3, overflow: "hidden" }}>
+            <CardMedia
+              onClick={handleCardClick}
+              component="img"
+              height="160"
+              image="https://avatars.githubusercontent.com/u/583231?v=4"
+              alt={repo.name ? `Image of ${repo.name}` : "Repository image"}
+              sx={{
+                borderRadius: 2,
+                boxShadow: 2,
+                objectFit: "cover",
+                marginBottom: 1,
+                cursor: "pointer",
+                transition: "transform 0.2s",
+              }}
+            />
+            <Box
+            sx={{
+              position: "absolute",         // <-- NEW: Overlay style
+              bottom: 0,                    // <-- Stick to bottom of image
+              width: "100%",
+              height: "40%",                // <-- Adjust gradient size as needed
+              background: "linear-gradient(to top, #111, rgba(17,17,17,0)))", // <-- Fade up into transparency
+              borderRadius: 2,              // <-- Match image border
+              pointerEvents: "none",        // <-- So it doesn’t block clicks
+            }}
+            /> */}
+            <Card sx={{ borderRadius: 3, overflow: "hidden", backgroundColor: (theme) => theme.palette.background.default, boxShadow: 3}}>
+            <Box sx={{ position: "relative" }}> {/* <-- NEW: Wrap image to allow overlay */}
+              <CardMedia
+                onClick={handleCardClick}
+                component="img"
+                height="170"
+                image="https://avatars.githubusercontent.com/u/583231?v=4"
+                alt={repo.name ? `Image of ${repo.name}` : "Repository image"}
+                sx={{
+                  borderRadius: 2,
+                  boxShadow: 2,
+                  objectFit: "cover",
+                  marginBottom: 1,
+                  cursor: "pointer",
+                  transition: "transform 0.2s",
+                }}
+              />
+              <Box
+                sx={{
+                  position: "absolute",         // <-- NEW: Overlay style
+                  bottom: 0,                    // <-- Stick to bottom of image
+                  width: "100%",
+                  height: "40%",                // <-- Adjust gradient size as needed
+                  background: "linear-gradient(to top, #111, rgba(15,15,15,0))", // <-- Fade up into transparency
+                  borderRadius: 2,              // <-- Match image border
+                  pointerEvents: "none",        // <-- So it doesn’t block clicks
+                }}
+              />
+            </Box>
+
+            <CardContent  sx={{ padding: 2 }}>
+            <Typography gutterBottom variant="h5" sx={{ fontWeight: 700, letterSpacing: 1 }}>
+            {repo.name}
             </Typography>
-          </CardContent>
+              <div className="repo-card-labels">
+                <div className="repo-card-tags">
+                  {repo.tags?.map((tag) => (
+                    <Chip
+                      size="small"  // <-- Add this line
+                      key={tag}
+                      label={tag}
+                      variant="outlined"
+                      sx={{ 
+                        margin: "2px",
+                        borderRadius: "10px", // <-- Change this value as you like
+                      }}
+                    />
+                  ))}
+                </div>
+                <div className="repo-card-rating">
+                  <Typography variant="body2" color="#fff" marginBottom={2}>
+                  ⭐  {repo.stars || "N/A"}
+                  </Typography>
+                </div>
+              </div>
+
+              <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                {repo.summary || "No summary available"}
+              </Typography>
+              <div className="repo-card-languages">
+                  {repo.languages?.map((language) => (
+                    <Chip
+                      size="small" 
+                      key={language}
+                      label={language}
+                      variant="filled" // <-- Change to filled
+                      sx={{ 
+                        margin: "2px",
+                        borderRadius: "10px",
+                        // color: "#90caf9", // <-- Text color (light blue)
+                        borderColor: "#90caf9", // <-- Outline color
+                      }}
+                    />
+                  ))}
+                </div>
+            </CardContent>
+          </Card>
         </CardActionArea>
       </Card>
 
@@ -221,7 +285,7 @@ export default function RepoCard({ repo, onSwipeLeft, onSwipeRight }) {
               top: "50%",
               left: "10px",
               transform: "translateY(-50%)",
-              color: "red",
+              color: "#E34714",
               fontSize: "24px",
               opacity: isDragging ? (currentX < -50 ? 1 : 0.3) : 1,
               transition: "opacity 0.2s",
@@ -257,7 +321,7 @@ export default function RepoCard({ repo, onSwipeLeft, onSwipeRight }) {
             onClick={handleRightClick}
             onMouseDown={(e) => e.stopPropagation()}
           >
-             <ArrowForwardIosIcon fontSize="large" />
+            <ArrowForwardIosIcon fontSize="large" />
           </Box>
         </>
       )}

--- a/branchout-ui/src/components/RepoCardModal/RepoCardModal.jsx
+++ b/branchout-ui/src/components/RepoCardModal/RepoCardModal.jsx
@@ -3,15 +3,16 @@ import { Modal, Box, Typography, CardMedia, Chip } from "@mui/material";
 
 const style = {
   position: 'absolute',
+  textAlign: "center",
   top: '50%',
   left: '50%',
   transform: 'translate(-50%, -50%)',
   width: 400,
   bgcolor: '#111',
   color: '#fff',
-  border: '2px solid #E83F25',
+  border: '2px solid transparent', // <-- Transparent border to maintain shape
   borderRadius: '20px',
-  boxShadow: '0 0 32px 8px rgba(232,63,37,0.18)',
+  boxShadow: '0 0 30px 6px rgba(232,63,37,0.5)', // <-- Stronger glow effect
   p: 4,
   marginLeft: '130px', // <-- set to your sidebar width
 
@@ -32,14 +33,14 @@ export default function RepoCardModal({ open, handleClose , repo}) {
             id="repo-modal-title"
             variant="h6"
             component="h2"
-            sx={{ color: "#E83F25", fontWeight: 700, mb: 2 }}
+            sx={{ textAlign: "center", color: "#E83F25", fontWeight: 700, mb: 2 }}
           >
             {repo.name}
           </Typography>
           <CardMedia
             component="img"
             height="140"
-            image="https://mui.com/static/images/cards/contemplative-reptile.jpg"
+            image="https://avatars.githubusercontent.com/u/583231?v=4"
             alt={repo.name ? `Image of ${repo.name}` : "Repository image"}
             sx={{
               borderRadius: "12px",
@@ -48,7 +49,7 @@ export default function RepoCardModal({ open, handleClose , repo}) {
             }}
           />
           <Box id="repo-modal-rating" sx={{ mt: 2 }}>
-            <span style={{ color: "#E83F25", fontWeight: 600 }}>Rating:</span> {repo.stars || "N/A"}
+            <span style={{ color: "#E83F25", fontWeight: 600 }}>⭐</span> {repo.stars || "N/A"}
           </Box>
           <Box id="repo-modal-tags" sx={{ mt: 2 }}>
             <span style={{ color: "#E83F25", fontWeight: 600 }}>Tags:</span>{" "}

--- a/branchout-ui/src/components/SavedRepoCard/SavedRepoCard.jsx
+++ b/branchout-ui/src/components/SavedRepoCard/SavedRepoCard.jsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import CardMedia from "@mui/material/CardMedia";
+import Typography from "@mui/material/Typography";
+import CardActionArea from "@mui/material/CardActionArea";
+import { Box } from "@mui/material";
+import RepoCardModal from "../RepoCardModal/RepoCardModal";
+
+export default function SavedRepoCard({ repo }) {
+const [open, setOpen] = useState(false);
+const handleClose = () => setOpen(false);
+
+return (
+    <>
+    <RepoCardModal open={open} handleClose={handleClose} repo={repo} />
+    <Card
+        sx={{
+        margin: 2,
+        maxWidth: 300,
+        borderRadius: 2,
+        border: 1,
+        borderColor: "#E34714",
+        boxShadow: 3,
+        background: "#111",
+        color: "#fff",
+        "&:hover": {
+            boxShadow: "0 0 20px rgba(232,63,37,0.15)",
+            transform: "scale(1.02)",
+        },
+        cursor: "pointer",
+        transition: "all 0.2s ease-in-out",
+        }}
+        onClick={() => setOpen(true)}
+    >
+        <CardActionArea>
+        <CardMedia
+            component="img"
+            height="140"
+            image="https://avatars.githubusercontent.com/u/583231?v=4"
+            alt={`Image of ${repo.name}`}
+            sx={{ objectFit: "cover", borderRadius: 2 }}
+        />
+        <CardContent>
+            <Typography
+            gutterBottom
+            variant="h6"
+            component="div"
+            sx={{ fontWeight: 600 }}
+            >
+            {repo.name}
+            </Typography>
+            <Typography
+            variant="body2"
+            sx={{ color: "#ccc", mb: 1 }}
+            noWrap
+            >
+            {repo.description || "No description available"}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+            ⭐ {repo.stars ?? "N/A"}
+            </Typography>
+        </CardContent>
+        </CardActionArea>
+    </Card>
+    </>
+);
+}

--- a/branchout-ui/src/pages/SavedReposPage/SavedRepos.css
+++ b/branchout-ui/src/pages/SavedReposPage/SavedRepos.css
@@ -1,0 +1,12 @@
+.repo-list {
+    display: flex;
+    flex-flow: row;
+    justify-content: center;
+
+}
+
+@media (max-width: 1300px ){
+    .repo-list{
+        flex-flow: row wrap;
+    }
+}

--- a/branchout-ui/src/pages/SavedReposPage/SavedReposPage.jsx
+++ b/branchout-ui/src/pages/SavedReposPage/SavedReposPage.jsx
@@ -2,6 +2,7 @@ import './SavedRepos.css';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import RepoCard from '../../components/RepoCard/RepoCard';
+import SavedRepoCard from '../../components/SavedRepoCard/SavedRepoCard';
 import { useAuth } from '../../components/ProtectedRoute/ProtectedRoute.jsx';
 
 function SavedReposPage() {
@@ -62,7 +63,7 @@ function SavedReposPage() {
       <h1>Saved Repositories</h1>
       <div className="repo-list">
         {repos.map((repo) => (
-          <RepoCard key={repo.id} repo={repo} />
+          <SavedRepoCard key={repo.id} repo={repo} />
         ))}
       </div>
     </div>


### PR DESCRIPTION
## What does this PR do?
This PR tweaks the saved Repo pages and the saved repo card component to display a different card view of the repository that the user saved. It also changes the image placeholder and tweaks the card modal that pops up.
## Context or Background
<!-- Explain the problem this PR is solving or the motivation for the change -->

## Checklist
- [x] Code compiles without errors
- [x] New features/fixes have been tested
- [x] Docs/README updated if needed

##  Related Ticket (Trello task link)
References: [Saved Repo Card Component](https://trello.com/c/2k1UCYFp/50-saved-repo-card-component)
##  Screenshots (if applicable)
<!-- Drag and drop or paste images here -->

---