### PR TITLE
Changed MCP server to run at 8001

### DIFF
--- a/branchout-llm-service/app/mcp_client.py
+++ b/branchout-llm-service/app/mcp_client.py
@@ -161,4 +161,4 @@ async def process_message(conversation_history: list) -> str:
         
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, host="0.0.0.0", port=8001)

--- a/branchout-ui/src/components/ChatBox/Chat.jsx
+++ b/branchout-ui/src/components/ChatBox/Chat.jsx
@@ -41,7 +41,7 @@ const Chat = () => {
     </style>
 
     useEffect(() => {
-        wsRef.current = new WebSocket('ws://localhost:8000/ws/chat');
+        wsRef.current = new WebSocket('ws://localhost:8001/ws/chat');
 
         wsRef.current.onopen = () => {
             console.log('WebSocket Connected');
@@ -107,7 +107,7 @@ const Chat = () => {
                     }
                     return nextText;
                 });
-            }, 30);
+            }, 20);
         }
     }
     


### PR DESCRIPTION
## What does this PR do?
Server previously ran on the same address as the python recommender algorithm, 8000. This just prevents either or from terminating due to the other being run. This PR also makes the typewriter effect on the chat bot to seem faster.
## Context or Background
<!-- Explain the problem this PR is solving or the motivation for the change -->

## Checklist
- [x] Code compiles without errors
- [x] New features/fixes have been tested
- [x] Docs/README updated if needed

##  Related Ticket (Trello task link)
<!-- References <link> -->

##  Screenshots (if applicable)
<!-- Drag and drop or paste images here -->

---