### PR TITLE
changed discovery and search page icons

### DIFF
--- a/branchout-ui/src/components/SideBar/SideBar.jsx
+++ b/branchout-ui/src/components/SideBar/SideBar.jsx
@@ -23,6 +23,7 @@ import {
 } from '@mui/material';
 import SettingsAccessibilityIcon from '@mui/icons-material/SettingsAccessibility';
 import InfoIcon from '@mui/icons-material/Info';
+import ExploreIcon from '@mui/icons-material/Explore';
 import {
   Home as HomeIcon,
   Settings as SettingsIcon,
@@ -35,7 +36,8 @@ import {
   Logout as LogoutIcon,
   AdminPanelSettings as AdminIcon
 } from '@mui/icons-material';
-import PersonSearchIcon from '@mui/icons-material/PersonSearch';import { useUser, useClerk } from '@clerk/clerk-react';
+import ManageSearchIcon from '@mui/icons-material/ManageSearch';
+import { useUser, useClerk } from '@clerk/clerk-react';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 
 const drawerWidth = 180;
@@ -119,12 +121,12 @@ export default function SideBar() {
           </MenuItem>
           <Divider />
           <MenuItem onClick={() => { handleMenuClose(); navigate('/discovery'); }}sx = {{color: isActive("/discovery") ? "#e34714" : "white"}}>
-            <PersonSearchIcon sx={{ mr: 2}} />
+            <ExploreIcon sx={{ mr: 2}} />
             Discovery
           </MenuItem>
           <Divider />
           <MenuItem onClick={() => { handleMenuClose(); navigate('/search'); }}sx = {{color: isActive("/search") ? "#e34714" : "white"}}>
-            <AppsIcon sx={{ mr: 2}} />
+            <ManageSearchIcon sx={{ mr: 2}} />
             Search
           </MenuItem>
           <Divider />
@@ -281,7 +283,7 @@ export default function SideBar() {
               }}
             >
               <ListItemIcon sx={{ minWidth: 0, justifyContent: 'center', display: 'flex', paddingBottom:"5px", paddingRight:"5px"}}>
-                <PersonSearchIcon sx={{ color: 'white' }} />
+                <ExploreIcon sx={{ color: 'white' }} />
               </ListItemIcon>
               {!isTablet && <ListItemText primary="Discovery" />}
             </ListItemButton>
@@ -310,7 +312,7 @@ export default function SideBar() {
               }}
             >
               <ListItemIcon sx={{ minWidth: 0, justifyContent: 'center', display: 'flex', paddingBottom:"5px", paddingRight:"5px"}}>
-                <AppsIcon sx={{ color: 'white' }} />
+                <ManageSearchIcon sx={{ color: 'white' }} />
               </ListItemIcon>
               {!isTablet && <ListItemText primary="Search" />}
             </ListItemButton>

--- a/branchout-ui/src/pages/DiscoveryPage/DiscoveryPage.jsx
+++ b/branchout-ui/src/pages/DiscoveryPage/DiscoveryPage.jsx
@@ -201,15 +201,9 @@ const DiscoveryPage = () => {
       const currentRepo = repos[currentIndex];
       if (!currentRepo) return;
 
-<<<<<<< Updated upstream
       if(e.key === "ArrowLeft"){
         handleSwipeLeft(currentRepo);
       } else if(e.key === "ArrowRight"){
-=======
-      if (e.key === "ArrowLeft" || e.key.toLowerCase() === "a") {
-        handleSwipeLeft(currentRepo);
-      } else if (e.key === "ArrowRight" || e.key.toLowerCase() === "d") {
->>>>>>> Stashed changes
         handleSwipeRight(currentRepo);
       }
     };


### PR DESCRIPTION
## What does this PR do?
<!-- A brief description of the feature, fix, or change -->
Discovery and Search Page icons properly reflect the names of the pages.

## Context or Background
<!-- Explain the problem this PR is solving or the motivation for the change -->
This creates less confusion for the users.

## Checklist
- [x] Code compiles without errors
- [x] New features/fixes have been tested
- [x] Docs/README updated if needed

##  Related Ticket (Trello task link)
<!-- References <link> -->
https://trello.com/c/p2d0Piiq

##  Screenshots (if applicable)
<!-- Drag and drop or paste images here -->
<img width="178" height="150" alt="Screenshot 2025-08-04 at 11 26 49 AM" src="https://github.com/user-attachments/assets/3cb7b0f5-cf76-4dc0-8c76-29d52464d442" />

---