### PR TITLE
Chat bot and Card modal tweaks

### DIFF
--- a/branchout-llm-service/app/mcp_client.py
+++ b/branchout-llm-service/app/mcp_client.py
@@ -34,133 +34,134 @@ server_params = StdioServerParameters(
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
 client = genai.Client(api_key=GEMINI_API_KEY)
 
-# define form of communication frontend -> here
 @app.websocket("/ws/chat")
 async def websocket_endpoint(websocket: WebSocket):
     await websocket.accept()
-    conversation_history = []  # This will store the chat history for this websocket session
+    conversation_history = []  # Per WebSocket connection chat history
 
-    try:
-        while True:
-            data = await websocket.receive_text()
-            print(f"Received: {data}") # run params on whats passed in
-
-            # Append user message to history
-            conversation_history.append({"role": "user", "parts": [data]})
-
-            # run mcp client logic block here
-            response = await process_message(conversation_history)
-            # Append assistant response to history
-            conversation_history.append({"role": "model", "parts": [response]})
-            
-            print(f"Response: {response}")
-
-            await websocket.send_text(response)
-    except WebSocketDisconnect:
-        print("Client disconnected")
-
-# async def run(Message: str):
-async def process_message(conversation_history: list) -> str:
     async with stdio_client(server_params) as (read, write):
         async with ClientSession(read, write) as session:
             await session.initialize()
 
-            GROUNDING_PROMPT = """
-            You have access to the following tools that allow you to retrieve real-time GitHub information about repositories, users, organizations, issues, and code to support open source discovery and contribution. 
-            You should call these tools whenever the user’s request involves GitHub data.
+            try:
+                while True:
+                    data = await websocket.receive_text()
+                    print(f"Received: {data}")
 
-            Here are the available API Tools:
+                    # Append user message to history
+                    conversation_history.append({"role": "user", "parts": [data]})
 
-            1. Fetch User Details (/users/{{username}})
-                - Provides details about a specific GitHub user.
-                - Use this to get information about a user, such as name, bio, avatar, and public repositories.
-                - Example LLM Query: "Show me details about the user torvalds."
+                    # Process message using persistent MCP session
+                    response = await process_message(session, conversation_history)
 
-            2. Fetch User Organizations (/users/{{username}}/orgs)
-                - Lists organizations that a user belongs to.
-                - Example LLM Query: "What organizations is gaearon a part of?"
+                    # Append model response to history
+                    conversation_history.append({"role": "model", "parts": [response]})
 
-            3. Fetch User Repositories (/users/{{username}}/repos)
-                - Lists public repositories for a specific user.
-                - Example LLM Query: "What repositories does torvalds own?"
+                    print(f"Response: {response}")
+                    await websocket.send_text(response)
 
-            4. Fetch Repository Details (/repos/{{owner}}/{{repo}})
-                - Retrieves metadata about a repository (description, owner, stars, forks, etc.)
-                - Example LLM Query: "Get details for the freeCodeCamp repository."
+            except WebSocketDisconnect:
+                print("Client disconnected")
 
-            5. Fetch Recent Commits in a Repository (/repos/{{owner}}/{{repo}}/commits)
-                - Retrieves the most recent commits (up to 3) in a repository.
-                - Example LLM Query: "What are the latest commits in the tensorflow repository?"
+async def process_message(session: ClientSession, conversation_history: list) -> str:
+    GROUNDING_PROMPT = """ 
+        You have access to the following tools that allow you to retrieve real-time GitHub information about repositories, users, organizations, issues, and code to support open source discovery and contribution. 
+        You should call these tools whenever the user’s request involves GitHub data.
 
-            6. Fetch Repository Labels (/repos/{{owner}}/{{repo}}/labels)
-                - Lists all labels available in a repository.
-                - Example LLM Query: "What are the issue labels in the vuejs/vue repository?"
+        Here are the available API Tools:
 
-            7. Fetch Repository Topics (/repos/{{owner}}/{{repo}}/topics)
-                - Retrieves the topics associated with a repository.
-                - Example LLM Query: "List topics for the nodejs/node repository."
+        1. Fetch User Details (/users/{{username}})
+            - Provides details about a specific GitHub user.
+            - Use this to get information about a user, such as name, bio, avatar, and public repositories.
+            - Example LLM Query: "Show me details about the user torvalds."
 
-            8. Fetch Repository README (/repos/{{owner}}/{{repo}}/readme)
-                - Retrieves and decodes the README file of a repository.
-                - Example LLM Query: "Show me the README of the django repository."
+        2. Fetch User Organizations (/users/{{username}}/orgs)
+            - Lists organizations that a user belongs to.
+            - Example LLM Query: "What organizations is gaearon a part of?"
 
-            9. Fetch CONTRIBUTING.md from a Repository (/repos/{{owner}}/{{repo}}/contents/CONTRIBUTING.md)
-                - Retrieves the contributing guidelines file if it exists.
-                - Example LLM Query: "Does the pytorch repository have a contributing guide?"
+        3. Fetch User Repositories (/users/{{username}}/repos)
+            - Lists public repositories for a specific user.
+            - Example LLM Query: "What repositories does torvalds own?"
 
-            10. Fetch Good First Issues (/repos/{{owner}}/{{repo}}/issues?labels=good%20first%20issue,help%20wanted)
-                - Lists open beginner-friendly issues for a repository.
-                - Example LLM Query: "Find me good first issues in the kubernetes/kubernetes repository."
+        4. Fetch Repository Details (/repos/{{owner}}/{{repo}})
+            - Retrieves metadata about a repository (description, owner, stars, forks, etc.)
+            - Example LLM Query: "Get details for the freeCodeCamp repository."
 
-            11. Search Code Snippets (/search/code?q={{query}})
-                - Searches for code snippets across repositories.
-                - Example LLM Query: "Search for the term 'GraphQL client' in GitHub code."
+        5. Fetch Recent Commits in a Repository (/repos/{{owner}}/{{repo}}/commits)
+            - Retrieves the most recent commits (up to 3) in a repository.
+            - Example LLM Query: "What are the latest commits in the tensorflow repository?"
 
-            12. Search Issues (/search/issues?q={{query}})
-                - Searches for issues based on a query string.
-                - Example LLM Query: "Search for issues mentioning 'CI/CD pipeline' in GitHub."
+        6. Fetch Repository Labels (/repos/{{owner}}/{{repo}}/labels)
+            - Lists all labels available in a repository.
+            - Example LLM Query: "What are the issue labels in the vuejs/vue repository?"
 
-            13. Search Repositories (/search/repositories?q={{query}})
-                - Searches repositories based on a query string.
-                - Example LLM Query: "Find repositories with the keyword 'machine learning'."
+        7. Fetch Repository Topics (/repos/{{owner}}/{{repo}}/topics)
+            - Retrieves the topics associated with a repository.
+            - Example LLM Query: "List topics for the nodejs/node repository."
 
-            14. Search Users (/search/users?q={{query}})
-                - Searches for users based on a query string.
-                - Example LLM Query: "Search for GitHub users named Alice."
+        8. Fetch Repository README (/repos/{{owner}}/{{repo}}/readme)
+            - Retrieves and decodes the README file of a repository.
+            - Example LLM Query: "Show me the README of the django repository."
 
-            15. Fetch Organization Details (/orgs/{{org}})
-                - Retrieves information about a GitHub organization.
-                - Example LLM Query: "Get details about the google organization on GitHub."
+        9. Fetch CONTRIBUTING.md from a Repository (/repos/{{owner}}/{{repo}}/contents/CONTRIBUTING.md)
+            - Retrieves the contributing guidelines file if it exists.
+            - Example LLM Query: "Does the pytorch repository have a contributing guide?"
 
-            16. Fetch Organization Repositories (/orgs/{{org}}/repos)
-                - Lists public repositories of a GitHub organization.
-                - Example LLM Query: "What repositories does Microsoft own?"
+        10. Fetch Good First Issues (/repos/{{owner}}/{{repo}}/issues?labels=good%20first%20issue&state=open)
+            - Lists open beginner-friendly issues for a repository.
+            - Example LLM Query: "Find me good first issues in the kubernetes/kubernetes repository."
+            - If no results are found, fallback to general open issues in the repository and look for titles or descriptions that imply beginner-friendly tasks (e.g., "easy", "good for starters", "simple fix").
 
-            17. Fetch Public Gists (/gists/public)
-                - Retrieves a list of recent public gists across GitHub.
-                - Example LLM Query: "Show me recent public gists on GitHub."
+        11. Search Code Snippets (/search/code?q={{query}})
+            - Searches for code snippets across repositories.
+            - Example LLM Query: "Search for the term 'GraphQL client' in GitHub code."
 
-                IMPORTANT INSTRUCTIONS: 
-                - Always return in raw markdown.
-                - Keep responses concise and informative. Avoid lengthy explanations or rambling.
-                - Limit responses to **150-200 words maximum**, unless explicitly asked for a detailed explanation.
-            """
+        12. Search Issues (/search/issues?q={{query}})
+            - Searches for issues based on a query string.
+            - Example LLM Query: "Search for issues mentioning 'CI/CD pipeline' in GitHub."
 
-            response = await client.aio.models.generate_content(
-                model="gemini-2.5-flash",
-                contents=[
-                    Content(role="model", parts=[Part(text=GROUNDING_PROMPT)]),
-                    *[
-                        Content(role=msg["role"], parts=[Part(text=part) for part in msg["parts"]])
-                        for msg in conversation_history
-                    ]
-                ],
-                config=genai.types.GenerateContentConfig(
-                    temperature=0,
-                    tools=[session],
-                ),
-            )
-            return response.candidates[0].content.parts[0].text
+        13. Search Repositories (/search/repositories?q={{query}})
+            - Searches repositories based on a query string.
+            - Example LLM Query: "Find repositories with the keyword 'machine learning'."
+
+        14. Search Users (/search/users?q={{query}})
+            - Searches for users based on a query string.
+            - Example LLM Query: "Search for GitHub users named Alice."
+
+        15. Fetch Organization Details (/orgs/{{org}})
+            - Retrieves information about a GitHub organization.
+            - Example LLM Query: "Get details about the google organization on GitHub."
+
+        16. Fetch Organization Repositories (/orgs/{{org}}/repos)
+            - Lists public repositories of a GitHub organization.
+            - Example LLM Query: "What repositories does Microsoft own?"
+
+        17. Fetch Public Gists (/gists/public)
+            - Retrieves a list of recent public gists across GitHub.
+            - Example LLM Query: "Show me recent public gists on GitHub."
+
+            IMPORTANT INSTRUCTIONS: 
+            - Always return in raw markdown.
+            - Keep responses concise and informative. Avoid lengthy explanations or rambling.
+            - Limit responses to **120-170 words maximum**, unless explicitly asked for a detailed explanation.
+            """  
+
+    response = await client.aio.models.generate_content(
+        model="gemini-2.5-flash",
+        contents=[
+            Content(role="model", parts=[Part(text=GROUNDING_PROMPT)]),
+            *[
+                Content(role=msg["role"], parts=[Part(text=part) for part in msg["parts"]])
+                for msg in conversation_history
+            ]
+        ],
+        config=genai.types.GenerateContentConfig(
+            temperature=0,
+            tools=[session],
+        ),
+    )
+    return response.candidates[0].content.parts[0].text
+
         
 if __name__ == "__main__":
     import uvicorn

--- a/branchout-ui/src/components/ChatBox/Chat.jsx
+++ b/branchout-ui/src/components/ChatBox/Chat.jsx
@@ -4,7 +4,7 @@ import {Paper, Grid, Divider, TextField, Typography, List, ListItem, ListItemTex
 import SendIcon from '@mui/icons-material/Send';
 import ChatIcon from '@mui/icons-material/Chat';
 import CloseIcon from '@mui/icons-material/Close';
-// require('dotenv').config(); // Load environment variables
+import { Link as MuiLink } from '@mui/material';
 
 const Chat = () => {
     const [message, setMessage] = useState('');
@@ -111,7 +111,6 @@ const Chat = () => {
             }, 20);
         }
     }
-    
 
     async function sendMessageToBackend(message) { // handle communication w websocket
         return new Promise((resolve, reject) => {
@@ -154,61 +153,138 @@ const Chat = () => {
 
             {/* Slide-in Drawer from Right */}
             <Drawer anchor="right" open={open} onClose={toggleDrawer(false)}>
-            <Box sx={{ width: 420, height: '100vh', display: 'flex', flexDirection: 'column', p: 0, m: 0 }}>
+                <Box sx={{
+                    width: { xs: '100%', sm: 420 },
+                    height: { xs: '100vh', sm: '80vh' },
+                    display: 'flex',
+                    flexDirection: 'column',
+                }} >
                     <Grid container alignItems="center" justifyContent="space-between" sx={{ m: 2 }}>
                         <Typography variant="h5">Ask Octocat!</Typography>
                         <Fab size="small" color="error" onClick={toggleDrawer(false)}>
-                            <CloseIcon color='primary'/>
+                            <CloseIcon color='primary.main'/>
                         </Fab>
                     </Grid>
 
-                    <Grid container component={Paper} sx={{ width: '100%' }}>
+                    <Grid container component={Paper} sx={{ flexGrow: 1, flexDirection: 'column', width: '100%' }}>
                         <Grid item xs={12}>
-                            <List sx={{ height: '88vh', overflowY: 'auto' }}>
+                            <List sx={{ height: '85vh', overflowY: 'auto' }}>
                                 {chat.map((c, i) => (
                                     <ListItem key={i} sx={{ justifyContent: c.from === 'Octocat' ? 'flex-start' : 'flex-end' }}>
                                         <Paper elevation={3} sx={{
-                                            p: 1.5,
+                                            p: 1, 
+                                            bgcolor: c.from === 'ME' ? 'primary.main' : (theme) => theme.palette.grey,
                                             maxWidth: '70%',
-                                            bgcolor: c.from === 'Octocat' ? 'linear-gradient(135deg, #f3f3f3 0%, #e0e0e0 100%)' : 'primary.main',
-                                            color: c.from === 'Octocat' ? 'white' : 'white',
-                                            borderRadius: c.from === 'Octocat' ? '12px' : '20px',
+                                            color: 'white',
+                                            borderRadius: '12px', 
+                                            textAlign: 'left',
+                                            wordBreak: 'break-word',
+                                            overflowWrap: 'break-word',
+                                            fontSize: '0.95rem',  
+                                            lineHeight: 1.2,    
                                         }}>
                                             {c.from === 'Octocat' ? (
-                                                <ReactMarkdown>{c.msg}</ReactMarkdown>
+                                                <ReactMarkdown
+                                                    components={{
+                                                        a: ({ node, ...props }) => (
+                                                            <MuiLink
+                                                                {...props}
+                                                                target="_blank"
+                                                                rel="noopener noreferrer"
+                                                                sx={{
+                                                                    wordBreak: 'break-word',
+                                                                    overflowWrap: 'break-word',
+                                                                    color: 'inherit',
+                                                                    textDecoration: 'underline'
+                                                                }}
+                                                            />
+                                                        )
+                                                    }}
+                                                >
+                                                    {c.msg}
+                                            </ReactMarkdown>
                                             ) : (
-                                                <ReactMarkdown >{c.msg}</ReactMarkdown>
+                                                    <ReactMarkdown
+                                                        components={{
+                                                            a: ({ node, ...props }) => (
+                                                                <MuiLink
+                                                                    {...props}
+                                                                    target="_blank"
+                                                                    rel="noopener noreferrer"
+                                                                    sx={{
+                                                                        wordBreak: 'break-word',
+                                                                        overflowWrap: 'break-word',
+                                                                        color: 'inherit',
+                                                                        textDecoration: 'underline'
+                                                                    }}
+                                                                />
+                                                            )
+                                                        }}
+                                                    >
+                                                        {c.msg}
+                                                    </ReactMarkdown>
                                             )}
-                                            <Typography variant="caption" sx={{ display: 'block', textAlign: c.from === 'Octocat' ? 'left' : 'right' }}>
+                                            <Typography variant="caption" sx={{
+                                                display: 'block',
+                                                textAlign: c.from === 'Octocat' ? 'left' : 'right',
+                                                mt: 0.5, // reduce margin-top
+                                                fontSize: '0.7rem', // smaller timestamp text
+                                                lineHeight: 1,
+                                            }}>
                                                 {c.from} at {c.time}
                                             </Typography>
                                         </Paper>
                                     </ListItem>
                                 ))}
+
                                 {isTyping && (
                                     <ListItem sx={{ justifyContent: 'flex-start' }}>
                                         <Paper elevation={3} sx={{
-                                            p: 1.5,
+                                            p: 1,
                                             maxWidth: '70%',
-                                            bgcolor: 'linear-gradient(135deg, #f3f3f3 0%, #e0e0e0 100%)',
                                             color: 'white',
-                                            borderRadius: '12px',
+                                            borderRadius: '12px', 
+                                            wordBreak: 'break-word',
+                                            overflowWrap: 'break-word',
+                                            fontSize: '0.95rem',
+                                            lineHeight: 1.2,
                                         }}>
-                                            <ReactMarkdown>{displayedMsg}</ReactMarkdown>
+                                            <ReactMarkdown
+                                                components={{
+                                                    a: ({ node, ...props }) => (
+                                                        <MuiLink
+                                                            {...props}
+                                                            target="_blank"
+                                                            rel="noopener noreferrer"
+                                                            sx={{
+                                                                wordBreak: 'break-word',
+                                                                overflowWrap: 'break-word',
+                                                                color: 'inherit',
+                                                                textDecoration: 'underline'
+                                                            }}
+                                                        />
+                                                    )
+                                                }}
+                                            >
+                                                {displayedMsg}
+                                            </ReactMarkdown>
                                             <Typography variant="caption" sx={{ display: 'block', textAlign: 'left' }}>
                                                 Octocat is typing...
                                             </Typography>
                                         </Paper>
                                     </ListItem>
                                 )}
+
                                 {showLoadingDots && (
                                     <ListItem sx={{ justifyContent: 'flex-start' }}>
                                         <Paper elevation={3} sx={{
-                                            p: 1.5,
+                                            p: 1,
                                             maxWidth: '70%',
-                                            bgcolor: 'gray',
+                                            bgcolor: 'gray', 
                                             color: 'white',
-                                            borderRadius: '12px',
+                                            borderRadius: '12px', 
+                                            wordBreak: 'break-word',
+                                            overflowWrap: 'break-word',
                                         }}>
                                             <Typography variant="body1">
                                                 <span className="dot">.</span>
@@ -218,6 +294,7 @@ const Chat = () => {
                                         </Paper>
                                     </ListItem>
                                 )}
+
                                 <div ref={bottomRef} />
                             </List>
                             <Divider />
@@ -239,6 +316,18 @@ const Chat = () => {
                                             boxShadow: 1,
                                             '& .MuiInputBase-root': {
                                                 padding: '8px 16px'
+                                            },
+                                            '& .MuiOutlinedInput-root': {
+                                                '& fieldset': {
+                                                    borderColor: 'transparent',
+                                                },
+                                                '&:hover fieldset': {
+                                                    borderColor: 'transparent',
+                                                },
+                                                '&.Mui-focused fieldset': {
+                                                    borderColor: 'transparent',
+                                                    boxShadow: 'none'
+                                                }
                                             }
                                         }}
                                     />
@@ -255,7 +344,6 @@ const Chat = () => {
                                     </Fab>
                                 </Box>
                             </Grid>
-
                         </Grid>
                     </Grid>
                 </Box>

--- a/branchout-ui/src/components/ChatBox/Chat.jsx
+++ b/branchout-ui/src/components/ChatBox/Chat.jsx
@@ -155,13 +155,20 @@ const Chat = () => {
             <Drawer anchor="right" open={open} onClose={toggleDrawer(false)}>
                 <Box sx={{
                     width: { xs: '100%', sm: 420 },
-                    height: { xs: '100vh', sm: '80vh' },
+                    height: { xs: '100dvh', sm: '80vh' },
                     display: 'flex',
                     flexDirection: 'column',
                 }} >
-                    <Grid container alignItems="center" justifyContent="space-between" sx={{ m: 2 }}>
+                    <Grid container alignItems="center" justifyContent="space-between" sx={{
+                        m: 1,
+                        flexWrap: 'nowrap',
+                        minHeight: '56px', // Give room on small screens
+                    }}>
                         <Typography variant="h5">Ask Octocat!</Typography>
-                        <Fab size="small" color="error" onClick={toggleDrawer(false)}>
+                        <Fab size="small" color="error" onClick={toggleDrawer(false)} sx={{
+                            zIndex: 1500, 
+                            position: 'relative' 
+                        }}>
                             <CloseIcon color='primary.main'/>
                         </Fab>
                     </Grid>

--- a/branchout-ui/src/components/RepoCard/RepoCard.jsx
+++ b/branchout-ui/src/components/RepoCard/RepoCard.jsx
@@ -291,7 +291,7 @@ export default function RepoCard({ repo, confidence , onSwipeLeft, onSwipeRight 
             <CardContent  sx={{ padding: {xs:1, md:1.5, display:"flex", flexDirection:"column", overflow:"hidden"}}}>
               <div className="repo-card-labels">
               <Box sx={{ position: 'relative', mb: 2 }}>
-                <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1 }}>
+                <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1, textAlign: 'left', alignContent: 'left', width: '100%' }}>
                   Related Tags:
                 </Typography>
                 <div className="repo-card-tags">
@@ -303,6 +303,8 @@ export default function RepoCard({ repo, confidence , onSwipeLeft, onSwipeRight 
                       label={tag}
                       variant="outlined"
                       sx={{ 
+                        textAlign: 'left',
+                        alignContent: 'left',
                         margin: "2px",
                         borderRadius: "10px", 
                         fontSize:{
@@ -364,12 +366,13 @@ export default function RepoCard({ repo, confidence , onSwipeLeft, onSwipeRight 
                 <span style={{ color: '#DAA7E2', fontWeight: 'bold', marginLeft: '4px', opacity: 0.8 }}>Read More</span>
               </Box>
               </Box>
+
               </Typography>
               <Box className="repo-card-languages" sx={{ mt: 2 }}>
-                <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1 }}>
+                <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1, textAlign: 'left', width: '100%' }}>
                   Languages Used:
                 </Typography>
-                <Box sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center' }}>
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'left', width:'100%' }}>
                 <FloatingIcon />
                   {repo.languages?.map((language) => (
                     <Chip
@@ -386,6 +389,7 @@ export default function RepoCard({ repo, confidence , onSwipeLeft, onSwipeRight 
                   ))}
                 </Box>
               </Box>
+
             </CardContent>
         </CardActionArea>
       </Card>
@@ -398,8 +402,8 @@ export default function RepoCard({ repo, confidence , onSwipeLeft, onSwipeRight 
               position: "absolute",
               top: "50%",
               left: {
-                xs:"20px",
-                md:"24px"
+                xs:"-8px",
+                md:"-10px"
               },
               transform: "translateY(-50%)",
               color: "#E34714",
@@ -429,8 +433,8 @@ export default function RepoCard({ repo, confidence , onSwipeLeft, onSwipeRight 
               position: "absolute",
               top: "50%",
               right: {
-                xs: "-20px",
-                md: "24px"
+                xs: "-25px",
+                md: "-20px"
               },
               transform: "translateY(-50%)",
               color: "green",

--- a/branchout-ui/src/components/RepoCard/RepoCard.jsx
+++ b/branchout-ui/src/components/RepoCard/RepoCard.jsx
@@ -364,7 +364,6 @@ export default function RepoCard({ repo, confidence , onSwipeLeft, onSwipeRight 
                 <span style={{ color: '#DAA7E2', fontWeight: 'bold', marginLeft: '4px', opacity: 0.8 }}>Read More</span>
               </Box>
               </Box>
-
               </Typography>
               <Box className="repo-card-languages" sx={{ mt: 2 }}>
                 <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1 }}>
@@ -387,7 +386,6 @@ export default function RepoCard({ repo, confidence , onSwipeLeft, onSwipeRight 
                   ))}
                 </Box>
               </Box>
-
             </CardContent>
         </CardActionArea>
       </Card>

--- a/branchout-ui/src/components/RepoCardModal/RepoCardModal.jsx
+++ b/branchout-ui/src/components/RepoCardModal/RepoCardModal.jsx
@@ -148,6 +148,16 @@ export default function RepoCardModal({ open, handleClose, repo }) {
         <Typography variant="body2" sx={{ color:theme.palette.text.primary, mb: 2}}>
           {repo.description || "No description available"}
         </Typography>
+
+          {/* Summary */}
+          <Box sx={{ width: "100%", textAlign: "left" }}>
+            <Typography variant="subtitle1" sx={{ color: theme.palette.text.primary, fontWeight: 600, mb: 1, alignItems: "left !important" }}>
+              Summary
+            </Typography>
+          </Box>
+          <Typography variant="body2" sx={{ color: theme.palette.text.primary, mb: 2 }}>
+            {repo.summary|| "No summary available"}
+          </Typography>
         
           <Box sx={{ width: '100%', height: '1px', backgroundColor: theme.palette.background.default, opacity: 0.3}} />
 


### PR DESCRIPTION
## What does this PR do?
This PR tweaks the prompt to limit the response word count overall, encourage the llm to suggest issues even if they are not good first issues, and it stopped from disconnecting the websocket everytime a query was made.

Additionally, this PR covers a series of tweaks regarding the chat bot UI such as links not wrapping in the ai response text bubble. It also accounts for spacing within the bubble and in the chat window itself. Additionally, this PR has some tweaks to the repo card and repo card modal to include summary on the modal, left align what already wasnt, and make the check and X icons further apart from the card.

## Context or Background
<!-- Explain the problem this PR is solving or the motivation for the change -->

## Checklist
- [x] Code compiles without errors
- [x] New features/fixes have been tested
- [x] Docs/README updated if needed

##  Related Ticket (Trello task link)
References [Repo card styling ](https://trello.com/c/C5QFJ7Ql/147-repo-card-styling), and [chat bot text responsiveness](https://trello.com/c/ZAcFtDIh/146-chat-bot-text-responsiveness)
##  Screenshots (if applicable)
<!-- Drag and drop or paste images here -->

---